### PR TITLE
feat: wrappers, ported, refatored and updated to latest libs

### DIFF
--- a/contracts/lp_account.fc
+++ b/contracts/lp_account.fc
@@ -1,6 +1,7 @@
 #pragma version >=0.2.0;
 
-#include "common/stdlib.fc";
+#include "imports/stdlib.fc";
+#include "common/extStdlib.fc";
 #include "common/messages.fc";
 #include "lp_account/op.fc";
 #include "lp_account/params.fc";

--- a/contracts/router.fc
+++ b/contracts/router.fc
@@ -1,6 +1,7 @@
 #pragma version >=0.2.0;
 
-#include "common/stdlib.fc";
+#include "imports/stdlib.fc";
+#include "common/extStdlib.fc";
 #include "common/gas.fc";
 #include "common/jetton-utils.fc";
 #include "common/messages.fc";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1188,19 +1188,6 @@
                 "tact": "bin/tact.js"
             }
         },
-        "node_modules/@tact-lang/compiler/node_modules/@ton/core": {
-            "version": "0.56.3",
-            "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.56.3.tgz",
-            "integrity": "sha512-HVkalfqw8zqLLPehtq0CNhu5KjVzc7IrbDwDHPjGoOSXmnqSobiWj8a5F+YuWnZnEbQKtrnMGNOOjVw4LG37rg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "symbol.inspect": "1.0.1"
-            },
-            "peerDependencies": {
-                "@ton/crypto": ">=3.2.0"
-            }
-        },
         "node_modules/@tact-lang/opcode": {
             "version": "0.0.16",
             "resolved": "https://registry.npmjs.org/@tact-lang/opcode/-/opcode-0.0.16.tgz",
@@ -1262,9 +1249,9 @@
             }
         },
         "node_modules/@ton/core": {
-            "version": "0.57.0",
-            "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.57.0.tgz",
-            "integrity": "sha512-UOehEXEV5yqi+17qmmWdD01YfVgQlYtitSm5OfN/WMg6PAMkt+Uf91JRC4mdPNtkKDhyKuujJuhYs6QiOsHPfw==",
+            "version": "0.56.3",
+            "resolved": "https://registry.npmjs.org/@ton/core/-/core-0.56.3.tgz",
+            "integrity": "sha512-HVkalfqw8zqLLPehtq0CNhu5KjVzc7IrbDwDHPjGoOSXmnqSobiWj8a5F+YuWnZnEbQKtrnMGNOOjVw4LG37rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1862,9 +1849,9 @@
             }
         },
         "node_modules/bn.js": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-            "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+            "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
             "dev": true,
             "license": "MIT"
         },
@@ -5509,13 +5496,6 @@
             "dependencies": {
                 "follow-redirects": "^1.14.7"
             }
-        },
-        "node_modules/ton/node_modules/bn.js": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-            "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/ton/node_modules/ton-crypto": {
             "version": "2.1.0",

--- a/wrappers/Account.compile.ts
+++ b/wrappers/Account.compile.ts
@@ -1,0 +1,6 @@
+import { CompilerConfig } from '@ton/blueprint';
+
+export const compile: CompilerConfig = {
+    lang: 'func',
+    targets: ['contracts/lp_account.fc'],
+};

--- a/wrappers/Account.ts
+++ b/wrappers/Account.ts
@@ -1,0 +1,82 @@
+import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
+import { beginMessage } from "./lib/helpers";
+
+export type AccountConfig = { 
+    user: Address;
+    pool: Address;
+    stored0: bigint;
+    stored1: bigint;
+};
+
+export function accountConfigToCell(config: AccountConfig): Cell {
+    return beginCell()
+        .storeAddress(config.user)
+        .storeAddress(config.pool)
+        .storeCoins(config.stored0)
+        .storeCoins(config.stored1)
+        .endCell();
+}
+
+export class Account implements Contract {
+    constructor(readonly address: Address, readonly init?: { code: Cell; data: Cell }) {}
+
+    static createFromAddress(address: Address) {
+        return new Account(address);
+    }
+
+    static createFromConfig(config:  AccountConfig, code: Cell, workchain = 0) {
+        const data = accountConfigToCell(config);
+        const init = { code, data };
+        return new Account(contractAddress(workchain, init), init);
+    }
+
+    async sendDeploy(provider: ContractProvider, via: Sender, value: bigint) {
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: beginCell().endCell(),
+        });
+    }
+
+
+
+ resetGas(): Cell {
+    return beginMessage({ op: BigInt(0x42a0fb43) })
+        .endCell();
+}
+
+ addLiquidity(params: {
+    newAmount0: bigint;
+    newAmount1: bigint;
+    minLPOut: bigint;
+}): Cell {
+    return beginMessage({ op: BigInt(0x3ebe5431) })
+        .storeCoins(params.newAmount0)
+        .storeCoins(params.newAmount1)
+        .storeCoins(params.minLPOut)
+        .endCell();
+}
+
+directAddLiquidity(params: {
+    amount0: bigint;
+    amount1: bigint;
+    minLPOut: bigint;
+}): Cell {
+    return beginMessage({ op: BigInt(0x4cf82803) })
+        .storeCoins(params.amount0)
+        .storeCoins(params.amount1)
+        .storeCoins(params.minLPOut)
+        .endCell();
+}
+
+ refundMe(): Cell {
+    return beginMessage({ op: BigInt(0x0bf3f447) })
+        .endCell();
+}
+
+ getLPAccountData(): Cell {
+    return beginMessage({ op: BigInt(0xea97bbef) })
+        .endCell();
+}
+
+}

--- a/wrappers/Pool.ts
+++ b/wrappers/Pool.ts
@@ -1,9 +1,42 @@
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
+import { beginMessage } from "./lib/helpers";
 
-export type PoolConfig = {};
+export type PoolConfig = {  routerAddress: Address;
+    lpFee: bigint;
+    protocolFee: bigint;
+    refFee: bigint;
+    protocolFeesAddress: Address;
+    collectedTokenAProtocolFees: bigint;
+    collectedTokenBProtocolFees: bigint;
+    reserve0: bigint;
+    reserve1: bigint;
+    wallet0: Address;
+    wallet1: Address;
+    supplyLP: bigint;
+    LPWalletCode: Cell;
+    LPAccountCode: Cell;};
 
 export function poolConfigToCell(config: PoolConfig): Cell {
-    return beginCell().endCell();
+    return beginCell()
+    .storeAddress(config.routerAddress)
+    .storeUint(config.lpFee, 8)
+    .storeUint(config.protocolFee, 8)
+    .storeUint(config.refFee, 8)
+    .storeAddress(config.wallet0)
+    .storeAddress(config.wallet1)
+    .storeCoins(config.supplyLP)
+    .storeRef(
+      beginCell()
+        .storeCoins(config.collectedTokenAProtocolFees)
+        .storeCoins(config.collectedTokenBProtocolFees)
+        .storeAddress(config.protocolFeesAddress)
+        .storeCoins(config.reserve0)
+        .storeCoins(config.reserve1)
+        .endCell()
+    )
+    .storeRef(config.LPWalletCode)
+    .storeRef(config.LPAccountCode)
+    .endCell();
 }
 
 export class Pool implements Contract {
@@ -26,4 +59,72 @@ export class Pool implements Contract {
             body: beginCell().endCell(),
         });
     }
+
+
+    setFees(params: { newLPFee: bigint; newProtocolFees: bigint; newRefFee: bigint; newProtocolFeeAddress: Address }): Cell {
+        return beginMessage({ op: BigInt(0x355423e5) })
+          .storeUint(params.newLPFee, 8)
+          .storeUint(params.newProtocolFees, 8)
+          .storeUint(params.newRefFee, 8)
+          .storeAddress(params.newProtocolFeeAddress)
+          .endCell();
+      }
+      
+    burnTokensNotification(params: { jettonAmount: bigint; fromAddress: Address; responseAddress: Address | null }): Cell {
+        return beginMessage({ op: BigInt(0x7bdd97de) })
+          .storeCoins(params.jettonAmount)
+          .storeAddress(params.fromAddress)
+          .storeAddress(params.responseAddress)
+          .endCell();
+      }
+      
+    collectFees(): Cell {
+        return beginMessage({ op: BigInt(0x1fcb7d3d) }).endCell();
+      }
+      
+    resetGas(): Cell {
+        return beginMessage({ op: BigInt(0x42a0fb43) }).endCell();
+      }
+      
+    swap(params: { fromAddress: Address; tokenWallet: Address; jettonAmount: bigint; toAddress: Address; minOutput: bigint; hasRef?: boolean; refAddress?: Address; }): Cell {
+        return beginMessage({ op: BigInt(0x25938561) })
+          .storeAddress(params.fromAddress)
+          .storeAddress(params.tokenWallet)
+          .storeCoins(params.jettonAmount)
+          .storeCoins(params.minOutput)
+          .storeBit(!!params.hasRef)
+          .storeBit(true)
+          .storeRef(beginCell()
+            .storeAddress(params.fromAddress)
+            .storeAddress(params.refAddress || null)
+            .endCell())
+          .endCell();
+      }
+      
+    provideLiquidity(params: { fromAddress: Address; jettonAmount0: bigint; jettonAmount1: bigint; minLPOut: bigint }): Cell {
+        return beginMessage({ op: BigInt(0xfcf9e58f) })
+          .storeAddress(params.fromAddress)
+          .storeCoins(params.minLPOut)
+          .storeCoins(params.jettonAmount0)
+          .storeCoins(params.jettonAmount1)
+          .endCell();
+      }
+      
+    getPoolData(): Cell {
+        return beginMessage({ op: BigInt(0x43c034e6) })
+          .endCell();
+      }
+      
+    getExpectedOutputs(params: { jettonAmount: bigint, tokenSent: Address }): Cell {
+        return beginMessage({ op: BigInt(0xed4d8b67) })
+          .storeCoins(params.jettonAmount)
+          .storeAddress(params.tokenSent)
+          .endCell();
+      }
+      
+    getCachedLPByAddress(params: { userAddress: Address }): Cell {
+        return beginMessage({ op: BigInt(0x0c0671db) })
+          .storeAddress(params.userAddress)
+          .endCell();
+      }      
 }

--- a/wrappers/Router.compile.ts
+++ b/wrappers/Router.compile.ts
@@ -1,0 +1,6 @@
+import { CompilerConfig } from '@ton/blueprint';
+
+export const compile: CompilerConfig = {
+    lang: 'func',
+    targets: ['contracts/router.fc'],
+};

--- a/wrappers/lib/helpers.ts
+++ b/wrappers/lib/helpers.ts
@@ -1,0 +1,7 @@
+import { Builder, beginCell } from '@ton/core';
+
+export function beginMessage(params: { op: bigint }): Builder {
+  return beginCell()
+    .storeUint(params.op, 32)
+    .storeUint(BigInt(Math.floor(Math.random() * 2 ** 31)), 64);
+}

--- a/wrappers/router.ts
+++ b/wrappers/router.ts
@@ -1,0 +1,168 @@
+import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, Sender, SendMode } from '@ton/core';
+import { beginMessage } from "./lib/helpers";
+
+export type RouterConfig = { isLocked: boolean; adminAddress: Address; LPWalletCode: Cell; poolCode: Cell; LPAccountCode: Cell; }
+
+export function routerConfigToCell(config: RouterConfig): Cell {
+    return beginCell()
+      .storeUint(config.isLocked ? 1 : 0, 1)
+      .storeAddress(config.adminAddress)
+      .storeRef(config.LPWalletCode)
+      .storeRef(config.poolCode)
+      .storeRef(config.LPAccountCode)
+      .storeRef(beginCell()
+        .storeUint(0, 64)
+        .storeUint(0, 64)
+        .storeAddress(null)
+        .storeRef(beginCell().endCell())
+        .endCell())
+      .endCell();
+}
+
+export class Router implements Contract {
+    constructor(readonly address: Address, readonly init?: { code: Cell; data: Cell }) {}
+
+    static createFromAddress(address: Address) {
+        return new Router(address);
+    }
+
+    static createFromConfig(config: RouterConfig, code: Cell, workchain = 0) {
+        const data = routerConfigToCell(config);
+        const init = { code, data };
+        return new Router(contractAddress(workchain, init), init);
+    }
+
+    async sendDeploy(provider: ContractProvider, via: Sender, value: bigint) {
+        await provider.internal(via, {
+            value,
+            sendMode: SendMode.PAY_GAS_SEPARATELY,
+            body: beginCell().endCell(),
+        });
+    }
+
+    setFees(params: {
+        jetton0Address: Address;
+        jetton1Address: Address;
+        newLPFee: bigint;
+        newProtocolFee: bigint;
+        newRefFee: bigint;
+        newProtocolFeeAddress: Address;
+      }): Cell {
+        return beginMessage({ op: BigInt(0x355423e5) })
+          .storeUint(params.newLPFee, 8)
+          .storeUint(params.newProtocolFee, 8)
+          .storeUint(params.newRefFee, 8)
+          .storeAddress(params.newProtocolFeeAddress)
+          .storeRef(beginCell()
+            .storeAddress(params.jetton0Address)
+            .storeAddress(params.jetton1Address)
+            .endCell())
+          .endCell();
+      }
+      
+      initCodeUpgrade(params: { newCode: Cell; }): Cell {
+        return beginMessage({ op: BigInt(0xdf1e233d) })
+          .storeRef(params.newCode)
+          .endCell();
+      }
+      
+       initAdminUpgrade(params: { newAdmin: Address; }): Cell {
+        return beginMessage({ op: BigInt(0x2fb94384) })
+          .storeAddress(params.newAdmin)
+          .endCell();
+      }
+      
+      cancelCodeUpgrade(): Cell {
+        return beginMessage({ op: BigInt(0x357ccc67) })
+          .endCell();
+      }
+      
+      cancelAdminUpgrade(): Cell {
+        return beginMessage({ op: BigInt(0xa4ed9981) })
+          .endCell();
+      }
+      
+      
+      finalizeUpgrades(): Cell {
+        return beginMessage({ op: BigInt(0x6378509f) })
+          .endCell();
+      }
+      
+      resetGas(): Cell {
+        return beginMessage({ op: BigInt(0x42a0fb43) }).endCell();
+      }
+      
+    lock(): Cell {
+        return beginMessage({ op: BigInt(0x878f9b0e) })
+          .endCell();
+      }
+      
+      unlock(): Cell {
+        return beginMessage({ op: BigInt(0x6ae4b0ef) })
+          .endCell();
+      }
+      
+     collectFees(params: {
+        jetton0Address: Address;
+        jetton1Address: Address;
+      }): Cell {
+        return beginMessage({ op: new BN(0x1fcb7d3d) })
+          .storeAddress(params.jetton0Address)
+          .storeAddress(params.jetton1Address)
+          .endCell();
+      }
+      
+      payTo(params: { owner: Address; tokenAAmount: BN; walletTokenAAddress: Address; tokenBAmount: BN; walletTokenBAddress: Address }): Cell {
+        return beginMessage({ op: new BN(0xf93bb43f) })
+          .storeAddress(params.owner)
+          .storeUint(new BN(0), 32)
+          .storeRef(
+            beginCell()
+              .storeCoins(params.tokenAAmount)
+              .storeAddress(params.walletTokenAAddress)
+              .storeCoins(params.tokenBAmount)
+              .storeAddress(params.walletTokenBAddress)
+              .endCell()
+          )
+          .endCell();
+      }
+      
+      swap(params: { jettonAmount: bigint; fromAddress: Address; walletTokenBAddress: Address; toAddress: Address; expectedOutput: bigint; refAddress?: Address; }): Cell {
+        let swapPayload = beginCell()
+          .storeUint(BigInt(0x25938561), 32)
+          .storeAddress(params.walletTokenBAddress)
+          .storeCoins(params.expectedOutput)
+          .storeAddress(params.toAddress)
+          .storeBit(!!params.refAddress);
+      
+        if (!!params.refAddress)
+          swapPayload.storeAddress(params.refAddress || null);
+      
+        return beginMessage({ op: BigInt(0x7362d09c) })
+          .storeCoins(params.jettonAmount)
+          .storeAddress(params.fromAddress)
+          .storeBit(true)
+          .storeRef(swapPayload.endCell())
+          .endCell();
+      }
+      
+      provideLiquidity(params: { jettonAmount: bigint; fromAddress: Address; walletTokenBAddress: Address; minLPOut: bigint }): Cell {
+        return beginMessage({ op: BigInt(0x7362d09c) })
+          .storeCoins(params.jettonAmount)
+          .storeAddress(params.fromAddress)
+          .storeBit(true)
+          .storeRef(beginCell()
+            .storeUint(BigInt(0xfcf9e58f), 32)
+            .storeAddress(params.walletTokenBAddress)
+            .storeCoins(params.minLPOut)
+            .endCell())
+          .endCell();
+      }
+      
+      getPoolAddress(params: { walletTokenAAddress: Address; walletTokenBAddress: Address }): Cell {
+        return beginMessage({ op: BigInt(0xd1db969b) })
+          .storeAddress(params.walletTokenAAddress)
+          .storeAddress(params.walletTokenBAddress)
+          .endCell();
+      }
+}


### PR DESCRIPTION
There  have been changes with additional imports required locally in the `stdlb`, they could be trimmed further to reduce file size (i.e. delete the functions not needed).

Modern wrappers use a OO approach and have been ported to `bigint` (native big number type, less resource then BN objects)

Closes #4 